### PR TITLE
BattleTowersConfig: Use platform-independent paths

### DIFF
--- a/src/main/java/com/github/draylar/battleTowers/config/BattleTowersConfig.java
+++ b/src/main/java/com/github/draylar/battleTowers/config/BattleTowersConfig.java
@@ -17,7 +17,7 @@ public class BattleTowersConfig
     public void checkConfigFolder()
     {
         // ping config path is [run environment]/config/ping
-        Path configPath = Paths.get(System.getProperty("user.dir") + "\\config\\battle-towers");
+        Path configPath = Paths.get(System.getProperty("user.dir") + "/config/battle-towers");
 
         if (configPath.toFile().isDirectory()) checkConfigFile(configPath);
 
@@ -38,7 +38,7 @@ public class BattleTowersConfig
      */
     public void checkConfigFile(Path path)
     {
-        Path jsonPath = Paths.get(path + "\\battle-towers.json");
+        Path jsonPath = Paths.get(path + "/battle-towers.json");
 
         if (!jsonPath.toFile().exists())
         {


### PR DESCRIPTION
On Linux `\` doesn't descend into directories, and in this case it creates big folder and file names like `.minecraft\config\battle-towers` and `.minecraft\config\battle-towers\battle-towers.json` in the `user.dir` directory.

I think using `/` should also work on windows and mac. As an added bonus, you don't have to escape it!

Tested and working on my (Linux) machine