### PR TITLE
Update to 19w13a, minor cleanups

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,12 +16,12 @@ repositories {
 }
 
 dependencies {
-	minecraft "com.mojang:minecraft:19w12b"
-	mappings "net.fabricmc:yarn:19w12b.7"
+	minecraft "com.mojang:minecraft:19w13a"
+	mappings "net.fabricmc:yarn:19w13a.3"
 	modCompile "net.fabricmc:fabric-loader:0.3.7.109"
 
 	//Fabric api
-	modCompile "net.fabricmc:fabric:0.2.5.114"
+	modCompile "net.fabricmc:fabric:0.2.6.116"
 }
 
 // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task

--- a/src/main/java/com/github/draylar/battleTowers/common/Entities.java
+++ b/src/main/java/com/github/draylar/battleTowers/common/Entities.java
@@ -3,12 +3,13 @@ package com.github.draylar.battleTowers.common;
 import com.github.draylar.battleTowers.common.entity.tower_guard.TowerGuardEntity;
 import net.fabricmc.fabric.api.entity.FabricEntityTypeBuilder;
 import net.minecraft.entity.EntityCategory;
+import net.minecraft.entity.EntitySize;
 import net.minecraft.entity.EntityType;
 import net.minecraft.util.registry.Registry;
 
 public class Entities
 {
-    public static final EntityType<TowerGuardEntity> towerGuard = FabricEntityTypeBuilder.<TowerGuardEntity>create(EntityCategory.CREATURE, TowerGuardEntity::new).size(3, 6).build();
+    public static final EntityType<TowerGuardEntity> towerGuard = FabricEntityTypeBuilder.<TowerGuardEntity>create(EntityCategory.CREATURE, TowerGuardEntity::new).size(EntitySize.resizeable(3, 6)).build();
 
     //  public static final EntityType<?> towerGuard = Registry.register(Registry.ENTITY_TYPE, "battle-towers:tower_guard", EntityType.Builder.<TowerGuardEntity>create(TowerGuardEntity::new, EntityCategory.CREATURE).build("tower_guard"));
 

--- a/src/main/java/com/github/draylar/battleTowers/common/Structures.java
+++ b/src/main/java/com/github/draylar/battleTowers/common/Structures.java
@@ -2,6 +2,7 @@ package com.github.draylar.battleTowers.common;
 
 import com.github.draylar.battleTowers.common.world.BattleTowerFeature;
 import com.github.draylar.battleTowers.common.world.BattleTowerGenerator;
+import com.github.draylar.battleTowers.config.ConfigHolder;
 import net.minecraft.structure.StructurePieceType;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biome;
@@ -32,7 +33,7 @@ public class Structures
             if(biome.getCategory() != Biome.Category.OCEAN && biome.getCategory() != Biome.Category.RIVER && biome.getCategory() != Biome.Category.NETHER && biome.getCategory() != Biome.Category.THE_END)
             {
                 biome.addStructureFeature(battleTowerFeature, new DefaultFeatureConfig());
-                biome.addFeature(GenerationStep.Feature.SURFACE_STRUCTURES, Biome.configureFeature(battleTowerFeature, new DefaultFeatureConfig(), Decorator.CHANCE_HEIGHTMAP, new ChanceDecoratorConfig(1000)));
+                biome.addFeature(GenerationStep.Feature.SURFACE_STRUCTURES, Biome.configureFeature(battleTowerFeature, new DefaultFeatureConfig(), Decorator.CHANCE_HEIGHTMAP, new ChanceDecoratorConfig(ConfigHolder.configInstance.structureRarity)));
             }
         }
     }

--- a/src/main/java/com/github/draylar/battleTowers/common/world/BattleTowerGenerator.java
+++ b/src/main/java/com/github/draylar/battleTowers/common/world/BattleTowerGenerator.java
@@ -125,12 +125,6 @@ public class BattleTowerGenerator
             {
                 iWorld.setBlockState(blockPos, Blocks.AIR.getDefaultState(), 3);
                 BlockEntity blockEntity = iWorld.getBlockEntity(blockPos.down());
-
-                if (blockEntity instanceof FurnaceBlockEntity)
-                {
-//                    ((FurnaceBlockEntity) blockEntity).setInvStack(0, new ItemStack(Items.WOODEN_AXE));
-//                    ((FurnaceBlockEntity) blockEntity).setInvStack(1, new ItemStack(Items.COAL));
-                }
             }
 
             else if (s.contains("normal_blacksmith_barrel"))


### PR DESCRIPTION
This updates the supported Minecraft version to 19w13a, which required absolutely no change at all.

The rest of the commits deal with minor code cleanups, and made structure rarity configuration actually change structure rarity.